### PR TITLE
`S3` path autocomplete & all files filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,8 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 
 ## 0.5.1 - 2021-06-23
 - fix issues with `Storage::disk()` method not being declared as static
+
+
+## 0.6.0 - 2021-06-24
+- add `autocompletePath()` method to `S3` for resolving partially complete directory paths with wildcard endings
+- add `allFiles()` method to `S3` for retrieving all files in a directory and then applying a filter

--- a/src/S3.php
+++ b/src/S3.php
@@ -233,8 +233,9 @@ class S3
         // Create array of all files
         $allFiles = $this->storageDisk()->allFiles($this->s3_key);
 
+        // Apply filtering closure
         if (isset($closure)) {
-            return $closure(array_values($allFiles));
+            return array_filter(array_values($allFiles), $closure);
         }
 
         return $allFiles;

--- a/src/S3.php
+++ b/src/S3.php
@@ -205,7 +205,8 @@ class S3
     public function autocompletePath(): self
     {
         // Extract the known $base of the path & the $wildcard
-        [$base, $wildcard] = [dirname($this->s3_key), basename($this->s3_key)];
+        $base = dirname($this->s3_key);
+        $wildcard = basename($this->s3_key);
 
         // Get all of the folders in the base directory
         $folders = $this->storageDisk()->directories($base);

--- a/src/S3.php
+++ b/src/S3.php
@@ -182,4 +182,30 @@ class S3
 
         return $files;
     }
+
+    /**
+     * Autocomplete an S3 path by providing the known start of a path.
+     *
+     * - once path autocompletion is resolved the $s3_key property is replaced with the found path
+     *
+     * @return $this
+     */
+    public function autocompletePath(): self
+    {
+        // Extract the known $base of the path & the $wildcard
+        list($base, $wildcard) = [dirname($this->s3_key), basename($this->s3_key)];
+
+        // Get all of the folders in the base directory
+        $folders = Storage::disk($this->disk)->directories($base);
+
+        // Filter folders to find the wildcard path
+        $folders = array_filter($folders, function ($value) use ($base, $wildcard) {
+            return str_starts_with($value, $base . DIRECTORY_SEPARATOR . $wildcard);
+        });
+
+        // return the resolved path
+        $this->s3_key = collect($folders)->values()->first();
+
+        return $this;
+    }
 }

--- a/src/S3.php
+++ b/src/S3.php
@@ -205,14 +205,14 @@ class S3
     public function autocompletePath(): self
     {
         // Extract the known $base of the path & the $wildcard
-        list($base, $wildcard) = [dirname($this->s3_key), basename($this->s3_key)];
+        [$base, $wildcard] = [dirname($this->s3_key), basename($this->s3_key)];
 
         // Get all of the folders in the base directory
         $folders = $this->storageDisk()->directories($base);
 
         // Filter folders to find the wildcard path
         $folders = array_filter($folders, function ($value) use ($base, $wildcard) {
-            return str_starts_with($value, $base . DIRECTORY_SEPARATOR . $wildcard);
+            return str_starts_with($value, $base.DIRECTORY_SEPARATOR.$wildcard);
         });
 
         // return the resolved path

--- a/src/S3.php
+++ b/src/S3.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Helpers\Aws\S3;
 
+use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Contracts\Filesystem\Filesystem;
@@ -224,11 +225,18 @@ class S3
     /**
      * Retrieve an array of all files in a directory with an optional filtering closure.
      *
+     * @param Closure|null $closure
      * @return array
      */
-    public function allFiles(): array
+    public function allFiles(Closure $closure = null): array
     {
         // Create array of all files
-        return $this->storageDisk()->allFiles($this->s3_key);
+        $allFiles = $this->storageDisk()->allFiles($this->s3_key);
+
+        if (isset($closure)) {
+            return $closure($allFiles);
+        }
+
+        return $allFiles;
     }
 }

--- a/src/S3.php
+++ b/src/S3.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\Helpers\Aws\S3;
 
-use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Contracts\Filesystem\Filesystem;
@@ -225,18 +224,11 @@ class S3
     /**
      * Retrieve an array of all files in a directory with an optional filtering closure.
      *
-     * @param Closure|null $closure
      * @return array
      */
-    public function allFiles(Closure $closure = null): array
+    public function allFiles(): array
     {
         // Create array of all files
-        $allFiles = $this->storageDisk()->allFiles($this->s3_key);
-
-        if (isset($closure)) {
-            return $closure($allFiles);
-        }
-
-        return $allFiles;
+        return $this->storageDisk()->allFiles($this->s3_key);
     }
 }

--- a/src/S3.php
+++ b/src/S3.php
@@ -234,7 +234,7 @@ class S3
         $allFiles = $this->storageDisk()->allFiles($this->s3_key);
 
         if (isset($closure)) {
-            return $closure($allFiles);
+            return $closure(array_values($allFiles));
         }
 
         return $allFiles;

--- a/src/S3.php
+++ b/src/S3.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Helpers\Aws\S3;
 
+use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Facades\Response;
@@ -207,5 +208,23 @@ class S3
         $this->s3_key = collect($folders)->values()->first();
 
         return $this;
+    }
+
+    /**
+     * Retrieve an array of all files in a directory with an optional filtering closure.
+     *
+     * @param Closure|null $closure
+     * @return array
+     */
+    public function allFiles(Closure $closure = null): array
+    {
+        // Create array of all files
+        $allFiles = Storage::disk($this->disk)->allFiles($this->s3_key);
+
+        if (isset($closure)) {
+            return $closure($allFiles);
+        }
+
+        return $allFiles;
     }
 }


### PR DESCRIPTION
- add `autocompletePath()` method to `S3` for resolving partially complete directory paths with wildcard endings
- add `allFiles()` method to `S3` for retrieving all files in a directory and then applying a filter