### PR TITLE
Fix helper functions breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,8 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 
 ## 0.7.1 - 2021-06-29
 - cut `exists()`, `missing()` & `delete()` methods from `S3Filesystem` interface & `S3` implementation because they are functionally the same as `Storage` facade methods
+
+
+## 0.7.2 - 2021-06-29
+- fix issue with `s3_exists()` helper function breaking (fixed for use in blades to avoid imports)
+- cut `s3_delete()` helper function as imports should be used instead

--- a/src/Helpers/s3-helpers.php
+++ b/src/Helpers/s3-helpers.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Storage;
 use Sfneal\Helpers\Aws\S3\Utils\S3;
 
 /**
@@ -42,7 +43,7 @@ function fileUrlTemp(string $path, DateTimeInterface $expiration = null): string
  */
 function s3_exists(string $s3_key): bool
 {
-    return (new S3($s3_key))->exists();
+    return Storage::disk('s3')->exists($s3_key);
 }
 
 /**
@@ -69,17 +70,6 @@ function s3_upload($s3_key, $file_path, $acl = null): string
 function s3_download($file_url, string $file_name = null): Response
 {
     return (new S3($file_url))->download($file_name);
-}
-
-/**
- * Delete a file or folder from an S3 bucket.
- *
- * @param $s3_key
- * @return bool
- */
-function s3_delete($s3_key): bool
-{
-    return (new S3($s3_key))->delete();
 }
 
 /**


### PR DESCRIPTION
- fix issue with `s3_exists()` helper function breaking (fixed for use in blades to avoid imports)
- cut `s3_delete()` helper function as imports should be used instead