### PR TITLE
Refactor helper functions naming conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,3 +69,7 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 ## 0.7.3 - 2021-06-29
 - make `HelpersTest` for testing helper functions
 - cut `s3_upload()`, `s3_download()` `s3_upload_raw()` & `s3_list()` helper functions
+
+
+## 0.8.0 - 2021-06-29
+- refactor helper functions to use camel case syntax & 's3{}' prefixes

--- a/src/Helpers/s3-helpers.php
+++ b/src/Helpers/s3-helpers.php
@@ -11,7 +11,7 @@ use Sfneal\Helpers\Aws\S3\Utils\S3;
  * @param DateTimeInterface|null $expiration
  * @return string
  */
-function fileURL(string $path, bool $temp = true, DateTimeInterface $expiration = null): string
+function s3FileURL(string $path, bool $temp = true, DateTimeInterface $expiration = null): string
 {
     // todo: refactor to `fileUrl()`
     if ($temp) {
@@ -22,13 +22,13 @@ function fileURL(string $path, bool $temp = true, DateTimeInterface $expiration 
 }
 
 /**
- * Return either a temporary S3 file url.
+ * Return a temporary S3 file url.
  *
  * @param string $path
  * @param DateTimeInterface|null $expiration
  * @return string
  */
-function fileUrlTemp(string $path, DateTimeInterface $expiration = null): string
+function s3FileUrlTemp(string $path, DateTimeInterface $expiration = null): string
 {
     return (new S3($path))->urlTemp($expiration);
 }
@@ -39,7 +39,7 @@ function fileUrlTemp(string $path, DateTimeInterface $expiration = null): string
  * @param string $s3_key
  * @return bool
  */
-function s3_exists(string $s3_key): bool
+function s3Exists(string $s3_key): bool
 {
     return Storage::disk('s3')->exists($s3_key);
 }

--- a/src/Utils/S3.php
+++ b/src/Utils/S3.php
@@ -160,7 +160,7 @@ class S3 implements S3Filesystem
         $files = [];
         if (isset($result['Contents']) && ! empty($result['Contents'])) {
             foreach ($result['Contents'] as $content) {
-                $url = fileURL($content['Key']);
+                $url = s3FileURL($content['Key']);
                 $parts = explode('/', explode('?', $url, 2)[0]);
                 $files[] = [
                     'name' => end($parts),

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -10,7 +10,7 @@ class HelpersTest extends StorageS3TestCase
     /** @test */
     public function file_url_exists()
     {
-        $url = fileURL($this->file, false);
+        $url = s3FileURL($this->file, false);
 
         $this->assertNotNull($url);
         $this->assertIsString($url);
@@ -20,7 +20,7 @@ class HelpersTest extends StorageS3TestCase
     /** @test */
     public function file_url_temp_exists()
     {
-        $url = fileUrlTemp($this->file);
+        $url = s3FileUrlTemp($this->file);
 
         $this->assertNotNull($url);
         $this->assertIsString($url);
@@ -31,7 +31,7 @@ class HelpersTest extends StorageS3TestCase
     /** @test */
     public function file_exists()
     {
-        $exists = s3_exists($this->file);
+        $exists = s3Exists($this->file);
 
         $this->assertIsBool($exists);
         $this->assertTrue($exists, "The file '{$this->file}' doesn't exist.");
@@ -40,7 +40,7 @@ class HelpersTest extends StorageS3TestCase
     /** @test */
     public function file_doesnt_exist()
     {
-        $doesntExist = s3_exists("fake_file_{$this->file}");
+        $doesntExist = s3Exists("fake_file_{$this->file}");
 
         $this->assertIsBool($doesntExist);
         $this->assertFalse($doesntExist);
@@ -49,7 +49,7 @@ class HelpersTest extends StorageS3TestCase
     /** @test */
     public function directory_exists()
     {
-        $exists = s3_exists('directory');
+        $exists = s3Exists('directory');
 
         $this->assertIsBool($exists);
         $this->assertTrue($exists);
@@ -58,7 +58,7 @@ class HelpersTest extends StorageS3TestCase
     /** @test */
     public function directory_doesnt_exist()
     {
-        $doesntExist = s3_exists('fake_directory');
+        $doesntExist = s3Exists('fake_directory');
 
         $this->assertIsBool($doesntExist);
         $this->assertFalse($doesntExist);


### PR DESCRIPTION
- refactor helper functions to use camel case syntax & 's3{}' prefixes