### PR TITLE
Fix issues with `autocompletePath()` & add new test classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,3 +73,9 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 
 ## 0.8.0 - 2021-06-29
 - refactor helper functions to use camel case syntax & 's3{}' prefixes
+
+
+## 0.8.1 - 2021-06-30
+- fix issues with `autocompletePath()` method causing errors when resolving paths in the root directory
+- add `getKey()` method to `S3`
+- make `AllDirectoriesTest`, `AllFilesTest`, `AutocompletePathTest` & `DownloadTest`

--- a/src/Helpers/s3-helpers.php
+++ b/src/Helpers/s3-helpers.php
@@ -13,7 +13,6 @@ use Sfneal\Helpers\Aws\S3\Utils\S3;
  */
 function s3FileURL(string $path, bool $temp = true, DateTimeInterface $expiration = null): string
 {
-    // todo: refactor to `fileUrl()`
     if ($temp) {
         return (new S3($path))->urlTemp($expiration);
     } else {

--- a/src/Utils/S3.php
+++ b/src/Utils/S3.php
@@ -194,14 +194,14 @@ class S3 implements S3Filesystem
     public function autocompletePath(): self
     {
         // Extract the known $base of the path & the $wildcard
-        list($base, $wildcard) = [dirname($this->s3Key), basename($this->s3Key)];
+        $directory = dirname($this->s3Key);
 
         // Get all of the folders in the base directory
-        $folders = $this->storageDisk()->directories($base);
+        $folders = $this->storageDisk()->directories($directory);
 
         // Filter folders to find the wildcard path
-        $folders = array_filter($folders, function ($value) use ($base, $wildcard) {
-            return str_starts_with($value, $base.DIRECTORY_SEPARATOR.$wildcard);
+        $folders = array_filter($folders, function ($value) {
+            return str_starts_with($value, $this->s3Key);
         });
 
         // return the resolved path

--- a/src/Utils/S3.php
+++ b/src/Utils/S3.php
@@ -10,6 +10,7 @@ use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Storage;
 use Sfneal\Helpers\Aws\S3\Interfaces\S3Filesystem;
+use Sfneal\Helpers\Aws\S3\StorageS3;
 
 class S3 implements S3Filesystem
 {
@@ -160,7 +161,7 @@ class S3 implements S3Filesystem
         $files = [];
         if (isset($result['Contents']) && ! empty($result['Contents'])) {
             foreach ($result['Contents'] as $content) {
-                $url = s3FileURL($content['Key']);
+                $url = StorageS3::key($content['Key'])->urlTemp();
                 $parts = explode('/', explode('?', $url, 2)[0]);
                 $files[] = [
                     'name' => end($parts),

--- a/src/Utils/S3.php
+++ b/src/Utils/S3.php
@@ -46,6 +46,16 @@ class S3 implements S3Filesystem
     }
 
     /**
+     * Retrieve the S3 key (useful in conjunctions with `autocompletePath()` method)
+     *
+     * @return string
+     */
+    public function getKey(): string
+    {
+        return $this->s3Key;
+    }
+
+    /**
      * Set the filesystem disk.
      *
      * @param string $disk
@@ -184,8 +194,7 @@ class S3 implements S3Filesystem
     public function autocompletePath(): self
     {
         // Extract the known $base of the path & the $wildcard
-        $base = dirname($this->s3Key);
-        $wildcard = basename($this->s3Key);
+        list($base, $wildcard) = [dirname($this->s3Key), basename($this->s3Key)];
 
         // Get all of the folders in the base directory
         $folders = $this->storageDisk()->directories($base);

--- a/src/Utils/S3.php
+++ b/src/Utils/S3.php
@@ -46,7 +46,7 @@ class S3 implements S3Filesystem
     }
 
     /**
-     * Retrieve the S3 key (useful in conjunctions with `autocompletePath()` method)
+     * Retrieve the S3 key (useful in conjunctions with `autocompletePath()` method).
      *
      * @return string
      */

--- a/tests/Unit/AllDirectoriesTest.php
+++ b/tests/Unit/AllDirectoriesTest.php
@@ -1,0 +1,42 @@
+<?php
+
+
+namespace Sfneal\Helpers\Aws\S3\Tests\Unit;
+
+
+use Sfneal\Helpers\Aws\S3\StorageS3;
+use Sfneal\Helpers\Aws\S3\Tests\TestCase;
+
+class AllDirectoriesTest extends TestCase
+{
+    /** @test */
+    public function all_directories_can_be_found()
+    {
+        $expected = [
+            'directory',
+            'directory/2021',
+            'directory/2021/20210001_first',
+            'directory/2021/20210002_second',
+            'directory_2021_06_30',
+        ];
+        $allDirectories = StorageS3::key('/')->allDirectories();
+
+        sort($expected);
+        sort($allDirectories);
+        $this->assertEquals($expected, $allDirectories);
+    }
+
+    /** @test */
+    public function all_directories_in_directory_can_be_found()
+    {
+        $expected = [
+            'directory/2021/20210001_first',
+            'directory/2021/20210002_second',
+        ];
+        $allDirectories = StorageS3::key('directory/2021')->allDirectories();
+
+        sort($expected);
+        sort($allDirectories);
+        $this->assertEquals($expected, $allDirectories);
+    }
+}

--- a/tests/Unit/AllDirectoriesTest.php
+++ b/tests/Unit/AllDirectoriesTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Helpers\Aws\S3\Tests\Unit;
-
 
 use Sfneal\Helpers\Aws\S3\StorageS3;
 use Sfneal\Helpers\Aws\S3\Tests\TestCase;

--- a/tests/Unit/AllFilesTest.php
+++ b/tests/Unit/AllFilesTest.php
@@ -1,0 +1,57 @@
+<?php
+
+
+namespace Sfneal\Helpers\Aws\S3\Tests\Unit;
+
+
+use Sfneal\Helpers\Aws\S3\StorageS3;
+use Sfneal\Helpers\Aws\S3\Tests\TestCase;
+
+class AllFilesTest extends TestCase
+{
+    /** @test */
+    public function all_files_can_be_found()
+    {
+        $expected = [
+            'article.pdf',
+            'charts.pdf',
+            'elevation.jpg',
+            'floor-plan.png',
+            'manual.pdf',
+            'workbook.pdf',
+            'directory/2021/20210002_second/article.pdf',
+            'directory/2021/20210002_second/charts.pdf',
+            'directory/2021/20210002_second/elevation.jpg',
+            'directory/2021/20210002_second/floor-plan.png',
+            'directory/2021/20210002_second/manual.pdf',
+            'directory/2021/20210002_second/workbook.pdf',
+            'elevation.jpg',
+            'floor-plan.png',
+            'manual.pdf',
+            'workbook.pdf',
+        ];
+        $allFiles = StorageS3::key('/')->allFiles();
+
+        $this->assertEquals(sort($expected), sort($allFiles));
+    }
+
+    /** @test */
+    public function all_files_in_directory_can_be_found()
+    {
+        $expected = [
+            'article.pdf',
+            'charts.pdf',
+            'elevation.jpg',
+            'floor-plan.png',
+            'manual.pdf',
+            'workbook.pdf',
+            'elevation.jpg',
+            'floor-plan.png',
+            'manual.pdf',
+            'workbook.pdf',
+        ];
+        $allFiles = StorageS3::key('directory/2021/20210002_second')->allFiles();
+
+        $this->assertEquals(sort($expected), sort($allFiles));
+    }
+}

--- a/tests/Unit/AllFilesTest.php
+++ b/tests/Unit/AllFilesTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Helpers\Aws\S3\Tests\Unit;
-
 
 use Sfneal\Helpers\Aws\S3\StorageS3;
 use Sfneal\Helpers\Aws\S3\Tests\TestCase;

--- a/tests/Unit/AllFilesTest.php
+++ b/tests/Unit/AllFilesTest.php
@@ -25,33 +25,29 @@ class AllFilesTest extends TestCase
             'directory/2021/20210002_second/floor-plan.png',
             'directory/2021/20210002_second/manual.pdf',
             'directory/2021/20210002_second/workbook.pdf',
-            'elevation.jpg',
-            'floor-plan.png',
-            'manual.pdf',
-            'workbook.pdf',
         ];
         $allFiles = StorageS3::key('/')->allFiles();
 
-        $this->assertEquals(sort($expected), sort($allFiles));
+        sort($expected);
+        sort($allFiles);
+        $this->assertEquals($expected, $allFiles);
     }
 
     /** @test */
     public function all_files_in_directory_can_be_found()
     {
         $expected = [
-            'article.pdf',
-            'charts.pdf',
-            'elevation.jpg',
-            'floor-plan.png',
-            'manual.pdf',
-            'workbook.pdf',
-            'elevation.jpg',
-            'floor-plan.png',
-            'manual.pdf',
-            'workbook.pdf',
+            'directory/2021/20210002_second/article.pdf',
+            'directory/2021/20210002_second/charts.pdf',
+            'directory/2021/20210002_second/elevation.jpg',
+            'directory/2021/20210002_second/floor-plan.png',
+            'directory/2021/20210002_second/manual.pdf',
+            'directory/2021/20210002_second/workbook.pdf',
         ];
         $allFiles = StorageS3::key('directory/2021/20210002_second')->allFiles();
 
-        $this->assertEquals(sort($expected), sort($allFiles));
+        sort($expected);
+        sort($allFiles);
+        $this->assertEquals($expected, $allFiles);
     }
 }

--- a/tests/Unit/AutocompletePathTest.php
+++ b/tests/Unit/AutocompletePathTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Helpers\Aws\S3\Tests\Unit;
-
 
 use Illuminate\Support\Facades\Storage;
 use Sfneal\Helpers\Aws\S3\StorageS3;

--- a/tests/Unit/AutocompletePathTest.php
+++ b/tests/Unit/AutocompletePathTest.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace Sfneal\Helpers\Aws\S3\Tests\Unit;
+
+
+use Illuminate\Support\Facades\Storage;
+use Sfneal\Helpers\Aws\S3\StorageS3;
+use Sfneal\Helpers\Aws\S3\Tests\TestCase;
+
+class AutocompletePathTest extends TestCase
+{
+    private function executeAssertions(string $expected, string $autocompleted)
+    {
+        $this->assertEquals($expected, $autocompleted);
+        $this->assertTrue(Storage::disk('s3')->exists($autocompleted));
+    }
+
+    /** @test */
+    public function nested_path_can_be_resolved()
+    {
+        $this->executeAssertions(
+            'directory/2021/20210001_first',
+            StorageS3::key('directory/2021/20210001')->autocompletePath()->getKey()
+        );
+    }
+
+    /** @test */
+    public function flat_path_can_be_resolved()
+    {
+        $this->executeAssertions(
+            'directory_2021_06_30',
+            StorageS3::key('directory_2021')->autocompletePath()->getKey()
+        );
+    }
+}

--- a/tests/Unit/DownloadTest.php
+++ b/tests/Unit/DownloadTest.php
@@ -1,0 +1,49 @@
+<?php
+
+
+namespace Sfneal\Helpers\Aws\S3\Tests\Unit;
+
+
+use Illuminate\Http\Response;
+use Sfneal\Helpers\Aws\S3\StorageS3;
+use Sfneal\Helpers\Aws\S3\Tests\StorageS3TestCase;
+
+class DownloadTest extends StorageS3TestCase
+{
+    /** @test */
+    public function file_can_be_downloaded()
+    {
+        $storage = StorageS3::key($this->file);
+        $response = $storage->download();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(file_get_contents($storage->url()), $response->content());
+    }
+
+    /** @test */
+    public function file_download_headers_are_correct()
+    {
+        $expectedHeaderKeys = [
+            'Content-Type',
+            'Content-Length',
+            'Content-Description',
+            'Content-Disposition',
+            'Content-Transfer-Encoding',
+        ];
+        $storage = StorageS3::key($this->file);
+        $response = $storage->download();
+
+        foreach ($expectedHeaderKeys as $key) {
+            $this->assertArrayHasKey(trim(strtolower($key)), $response->headers->all());
+        }
+    }
+
+    /** @test */
+    public function file_download_response_code()
+    {
+        $storage = StorageS3::key($this->file);
+        $response = $storage->download();
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+}

--- a/tests/Unit/DownloadTest.php
+++ b/tests/Unit/DownloadTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Helpers\Aws\S3\Tests\Unit;
-
 
 use Illuminate\Http\Response;
 use Sfneal\Helpers\Aws\S3\StorageS3;


### PR DESCRIPTION
- fix issues with `autocompletePath()` method causing errors when resolving paths in the root directory
- add `getKey()` method to `S3`
- make `AllDirectoriesTest`, `AllFilesTest`, `AutocompletePathTest` & `DownloadTest`