### PR TITLE
optimize `S3::upload()` & `S3::upload_raw()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,3 +79,8 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 - fix issues with `autocompletePath()` method causing errors when resolving paths in the root directory
 - add `getKey()` method to `S3`
 - make `AllDirectoriesTest`, `AllFilesTest`, `AutocompletePathTest` & `DownloadTest`
+
+
+## 0.9.0 - 2021-06-30
+- fix return type of `S3` upload function to return the class instance instead of a url
+- optimize `S3::upload()` & `S3::upload_raw()` methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,3 +84,4 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 ## 0.9.0 - 2021-06-30
 - fix return type of `S3` upload function to return the class instance instead of a url
 - optimize `S3::upload()` & `S3::upload_raw()` methods
+- refactor `S3::upload_raw()` to `S3::uploadRaw()`

--- a/src/Interfaces/S3Filesystem.php
+++ b/src/Interfaces/S3Filesystem.php
@@ -40,7 +40,7 @@ interface S3Filesystem
      * @param string|null $acl
      * @return self
      */
-    public function upload_raw($fileContents, string $acl = null): self;
+    public function uploadRaw($fileContents, string $acl = null): self;
 
     /**
      * Download a file from AWS S3.

--- a/src/Interfaces/S3Filesystem.php
+++ b/src/Interfaces/S3Filesystem.php
@@ -29,18 +29,18 @@ interface S3Filesystem
      *
      * @param string $localFilePath
      * @param string|null $acl
-     * @return string
+     * @return self
      */
-    public function upload(string $localFilePath, string $acl = null): string;
+    public function upload(string $localFilePath, string $acl = null): self;
 
     /**
      * Upload raw file contents to AWS S3.
      *
      * @param string $fileContents
      * @param string|null $acl
-     * @return string
+     * @return self
      */
-    public function upload_raw(string $fileContents, string $acl = null): string;
+    public function upload_raw(string $fileContents, string $acl = null): self;
 
     /**
      * Download a file from AWS S3.

--- a/src/Interfaces/S3Filesystem.php
+++ b/src/Interfaces/S3Filesystem.php
@@ -36,11 +36,11 @@ interface S3Filesystem
     /**
      * Upload raw file contents to AWS S3.
      *
-     * @param string $fileContents
+     * @param $fileContents
      * @param string|null $acl
      * @return self
      */
-    public function upload_raw(string $fileContents, string $acl = null): self;
+    public function upload_raw($fileContents, string $acl = null): self;
 
     /**
      * Download a file from AWS S3.

--- a/src/Utils/S3.php
+++ b/src/Utils/S3.php
@@ -110,11 +110,7 @@ class S3 implements S3Filesystem
      */
     public function upload_raw($fileContents, string $acl = null): self
     {
-        if (is_null($acl)) {
-            $this->storageDisk()->put($this->s3Key, $fileContents);
-        } else {
-            $this->storageDisk()->put($this->s3Key, $fileContents, $acl);
-        }
+        $this->storageDisk()->put($this->s3Key, $fileContents, $acl);
 
         return $this;
     }

--- a/src/Utils/S3.php
+++ b/src/Utils/S3.php
@@ -98,23 +98,17 @@ class S3 implements S3Filesystem
      */
     public function upload(string $localFilePath, string $acl = null): self
     {
-        if (is_null($acl)) {
-            $this->storageDisk()->put($this->s3Key, fopen($localFilePath, 'r+'));
-        } else {
-            $this->storageDisk()->put($this->s3Key, fopen($localFilePath, 'r+'), $acl);
-        }
-
-        return $this;
+        return $this->upload_raw(fopen($localFilePath, 'r+'), $acl);
     }
 
     /**
      * Upload raw file contents to an S3 bucket.
      *
-     * @param string $fileContents
+     * @param $fileContents
      * @param string|null $acl
      * @return self
      */
-    public function upload_raw(string $fileContents, string $acl = null): self
+    public function upload_raw($fileContents, string $acl = null): self
     {
         if (is_null($acl)) {
             $this->storageDisk()->put($this->s3Key, $fileContents);

--- a/src/Utils/S3.php
+++ b/src/Utils/S3.php
@@ -94,9 +94,9 @@ class S3 implements S3Filesystem
      *
      * @param string $localFilePath
      * @param string|null $acl
-     * @return string
+     * @return self
      */
-    public function upload(string $localFilePath, string $acl = null): string
+    public function upload(string $localFilePath, string $acl = null): self
     {
         if (is_null($acl)) {
             $this->storageDisk()->put($this->s3Key, fopen($localFilePath, 'r+'));
@@ -104,8 +104,7 @@ class S3 implements S3Filesystem
             $this->storageDisk()->put($this->s3Key, fopen($localFilePath, 'r+'), $acl);
         }
 
-        // todo: refactor to return 'self'
-        return $this->url();
+        return $this;
     }
 
     /**
@@ -113,9 +112,9 @@ class S3 implements S3Filesystem
      *
      * @param string $fileContents
      * @param string|null $acl
-     * @return string
+     * @return self
      */
-    public function upload_raw(string $fileContents, string $acl = null): string
+    public function upload_raw(string $fileContents, string $acl = null): self
     {
         if (is_null($acl)) {
             $this->storageDisk()->put($this->s3Key, $fileContents);
@@ -123,8 +122,7 @@ class S3 implements S3Filesystem
             $this->storageDisk()->put($this->s3Key, $fileContents, $acl);
         }
 
-        // todo: refactor to return 'self'
-        return $this->url();
+        return $this;
     }
 
     /**

--- a/src/Utils/S3.php
+++ b/src/Utils/S3.php
@@ -98,7 +98,7 @@ class S3 implements S3Filesystem
      */
     public function upload(string $localFilePath, string $acl = null): self
     {
-        return $this->upload_raw(fopen($localFilePath, 'r+'), $acl);
+        return $this->uploadRaw(fopen($localFilePath, 'r+'), $acl);
     }
 
     /**
@@ -108,7 +108,7 @@ class S3 implements S3Filesystem
      * @param string|null $acl
      * @return self
      */
-    public function upload_raw($fileContents, string $acl = null): self
+    public function uploadRaw($fileContents, string $acl = null): self
     {
         $this->storageDisk()->put($this->s3Key, $fileContents, $acl);
 

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -38,9 +38,11 @@ class UploadTest extends StorageS3TestCase
     /** @test */
     public function file_can_be_uploaded()
     {
-        StorageS3::key($this->uploadPath)->upload(__DIR__.'/../Assets/'.$this->file);
+        $s3Key = StorageS3::key($this->uploadPath)
+            ->upload(__DIR__.'/../Assets/'.$this->file)
+            ->getKey();
 
-        $exists = Storage::disk('s3')->exists($this->uploadPath);
+        $exists = Storage::disk('s3')->exists($s3Key);
 
         $this->assertIsBool($exists);
         $this->assertTrue($exists, "The file '{$this->file}' doesn't exist.");
@@ -49,9 +51,11 @@ class UploadTest extends StorageS3TestCase
     /** @test */
     public function file_can_be_uploaded_raw()
     {
-        StorageS3::key($this->uploadPath)->upload_raw(file_get_contents(__DIR__.'/../Assets/'.$this->file));
+        $s3Key = StorageS3::key($this->uploadPath)
+            ->upload_raw(file_get_contents(__DIR__.'/../Assets/'.$this->file))
+            ->getKey();
 
-        $exists = Storage::disk('s3')->exists($this->uploadPath);
+        $exists = Storage::disk('s3')->exists($s3Key);
 
         $this->assertIsBool($exists);
         $this->assertTrue($exists, "The file '{$this->file}' doesn't exist.");

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -52,7 +52,7 @@ class UploadTest extends StorageS3TestCase
     public function file_can_be_uploaded_raw()
     {
         $s3Key = StorageS3::key($this->uploadPath)
-            ->upload_raw(file_get_contents(__DIR__.'/../Assets/'.$this->file))
+            ->uploadRaw(file_get_contents(__DIR__.'/../Assets/'.$this->file))
             ->getKey();
 
         $exists = Storage::disk('s3')->exists($s3Key);


### PR DESCRIPTION
- fix return type of `S3` upload function to return the class instance instead of a url
- optimize `S3::upload()` & `S3::upload_raw()` methods
- refactor `S3::upload_raw()` to `S3::uploadRaw()`