### PR TITLE
Cut `S3::list()` method & add use of filesystems config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,3 +85,9 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 - fix return type of `S3` upload function to return the class instance instead of a url
 - optimize `S3::upload()` & `S3::upload_raw()` methods
 - refactor `S3::upload_raw()` to `S3::uploadRaw()`
+
+
+## 0.10.0 - 2021-07-01
+- optimize `s3FileUrl()` helper method by removing $temp param
+- cut `S3::list()` method as it was behaving unexpectedly and is no longer used
+- fix use of `Storage::disk('s3')` with `Storage::disk(config('filesystem.cloud', 's3'))` to make use of config

--- a/src/Helpers/s3-helpers.php
+++ b/src/Helpers/s3-helpers.php
@@ -34,5 +34,5 @@ function s3FileUrlTemp(string $path, DateTimeInterface $expiration = null): stri
  */
 function s3Exists(string $s3_key): bool
 {
-    return Storage::disk('s3')->exists($s3_key);
+    return Storage::disk(config('filesystem.cloud', 's3'))->exists($s3_key);
 }

--- a/src/Helpers/s3-helpers.php
+++ b/src/Helpers/s3-helpers.php
@@ -1,23 +1,17 @@
 <?php
 
 use Illuminate\Support\Facades\Storage;
-use Sfneal\Helpers\Aws\S3\Utils\S3;
+use Sfneal\Helpers\Aws\S3\StorageS3;
 
 /**
  * Return either an S3 file url.
  *
  * @param string $path
- * @param bool $temp
- * @param DateTimeInterface|null $expiration
  * @return string
  */
-function s3FileURL(string $path, bool $temp = true, DateTimeInterface $expiration = null): string
+function s3FileURL(string $path): string
 {
-    if ($temp) {
-        return (new S3($path))->urlTemp($expiration);
-    } else {
-        return (new S3($path))->url();
-    }
+    return StorageS3::key($path)->url();
 }
 
 /**
@@ -29,7 +23,7 @@ function s3FileURL(string $path, bool $temp = true, DateTimeInterface $expiratio
  */
 function s3FileUrlTemp(string $path, DateTimeInterface $expiration = null): string
 {
-    return (new S3($path))->urlTemp($expiration);
+    return StorageS3::key($path)->urlTemp($expiration);
 }
 
 /**

--- a/src/Interfaces/S3Filesystem.php
+++ b/src/Interfaces/S3Filesystem.php
@@ -53,13 +53,6 @@ interface S3Filesystem
     public function download(string $fileName = null): Response;
 
     /**
-     * List all of the files in an S3 directory & return an array of files with constructed URLs.
-     *
-     * @return array
-     */
-    public function list(): array;
-
-    /**
      * Autocomplete an S3 path by providing the known start of a path.
      *
      * - once path autocompletion is resolved the $s3_key property is replaced with the found path

--- a/src/Utils/S3.php
+++ b/src/Utils/S3.php
@@ -10,7 +10,6 @@ use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Storage;
 use Sfneal\Helpers\Aws\S3\Interfaces\S3Filesystem;
-use Sfneal\Helpers\Aws\S3\StorageS3;
 
 class S3 implements S3Filesystem
 {
@@ -140,36 +139,6 @@ class S3 implements S3Filesystem
         ];
 
         return Response::make($this->storageDisk()->get($this->s3Key), 200, $response);
-    }
-
-    /**
-     * List all of the files in an S3 directory.
-     *
-     * @return array
-     */
-    public function list(): array
-    {
-        $storage = $this->storageDisk();
-        $client = $storage->getAdapter()->getClient();
-        $command = $client->getCommand('ListObjects');
-        $command['Bucket'] = $storage->getAdapter()->getBucket();
-        $command['Prefix'] = $this->s3Key;
-        $result = $client->execute($command);
-
-        $files = [];
-        if (isset($result['Contents']) && ! empty($result['Contents'])) {
-            foreach ($result['Contents'] as $content) {
-                $url = StorageS3::key($content['Key'])->urlTemp();
-                $parts = explode('/', explode('?', $url, 2)[0]);
-                $files[] = [
-                    'name' => end($parts),
-                    'url' => $url,
-                    'key' => $content['Key'],
-                ];
-            }
-        }
-
-        return $files;
     }
 
     /**

--- a/tests/StorageS3TestCase.php
+++ b/tests/StorageS3TestCase.php
@@ -2,7 +2,7 @@
 
 namespace Sfneal\Helpers\Aws\S3\Tests;
 
-class StorageS3TestCase extends TestCase
+abstract class StorageS3TestCase extends TestCase
 {
     /**
      * Retrieve an array of asset files.

--- a/tests/Unit/AutocompletePathTest.php
+++ b/tests/Unit/AutocompletePathTest.php
@@ -11,7 +11,7 @@ class AutocompletePathTest extends TestCase
     private function executeAssertions(string $expected, string $autocompleted)
     {
         $this->assertEquals($expected, $autocompleted);
-        $this->assertTrue(Storage::disk('s3')->exists($autocompleted));
+        $this->assertTrue(Storage::disk(config('filesystem.cloud', 's3'))->exists($autocompleted));
     }
 
     /** @test */

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -42,7 +42,7 @@ class UploadTest extends StorageS3TestCase
             ->upload(__DIR__.'/../Assets/'.$this->file)
             ->getKey();
 
-        $exists = Storage::disk('s3')->exists($s3Key);
+        $exists = Storage::disk(config('filesystem.cloud', 's3'))->exists($s3Key);
 
         $this->assertIsBool($exists);
         $this->assertTrue($exists, "The file '{$this->file}' doesn't exist.");
@@ -55,7 +55,7 @@ class UploadTest extends StorageS3TestCase
             ->uploadRaw(file_get_contents(__DIR__.'/../Assets/'.$this->file))
             ->getKey();
 
-        $exists = Storage::disk('s3')->exists($s3Key);
+        $exists = Storage::disk(config('filesystem.cloud', 's3'))->exists($s3Key);
 
         $this->assertIsBool($exists);
         $this->assertTrue($exists, "The file '{$this->file}' doesn't exist.");


### PR DESCRIPTION
- optimize `s3FileUrl()` helper method by removing $temp param
- cut `S3::list()` method as it was behaving unexpectedly and is no longer used
- fix use of `Storage::disk('s3')` with `Storage::disk(config('filesystem.cloud', 's3'))` to make use of config