### PR TITLE
Phpunit data providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,3 +96,7 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 ## 0.10.1 - 2021-07-01
 - add file content assertions to test suites to more accurately determine if the tests were successful
 - make `S3FilesystemTest`, `S3Test` & `StorageS3Test` tests for testing methods & interface implementations
+
+
+## 0.10.2 - 2021-07-01
+- add use of phpunit 'data providers' in order to run test methods on each test file (instead of a single random one)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,3 +100,4 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 
 ## 0.10.2 - 2021-07-01
 - add use of phpunit 'data providers' in order to run test methods on each test file (instead of a single random one)
+- bump min laravel/framework version to v8.40 to avoid security vulnerabilities & improve Travis CI runtime

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.4",
         "aws/aws-sdk-php": "^3.185",
-        "laravel/framework": ">=5.0",
+        "laravel/framework": ">=8.40",
         "league/flysystem-aws-s3-v3": ">=1.0.29"
     },
     "require-dev": {

--- a/tests/Feature/StorageS3Test.php
+++ b/tests/Feature/StorageS3Test.php
@@ -22,21 +22,29 @@ class StorageS3Test extends StorageS3TestCase
         }
     }
 
-    /** @test */
-    public function key_method_return_s3_instance()
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     */
+    public function key_method_return_s3_instance(string $file)
     {
         $this->assertInstanceOf(
             S3::class,
-            StorageS3::key($this->file)
+            StorageS3::key($file)
         );
     }
 
-    /** @test */
-    public function disk_method_return_s3_instance()
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     */
+    public function disk_method_return_s3_instance(string $file)
     {
         $this->assertInstanceOf(
             S3::class,
-            StorageS3::disk(config('filesystems.cloud', 's3'), $this->file)
+            StorageS3::disk(config('filesystems.cloud', 's3'), $file)
         );
     }
 }

--- a/tests/StorageS3TestCase.php
+++ b/tests/StorageS3TestCase.php
@@ -9,37 +9,14 @@ abstract class StorageS3TestCase extends TestCase
      *
      * @return array
      */
-    private static function files(): array
+    public function fileProvider(): array
     {
-        return array_diff(scandir(__DIR__.'/Assets'), ['.', '..']);
-    }
-
-    /**
-     * Retrieve a random asset file.
-     *
-     * @return string
-     */
-    public static function randomFile(): string
-    {
-        $files = self::files();
-        $file = array_rand($files);
-
-        return $files[$file];
-    }
-
-    /**
-     * @var string
-     */
-    protected $file;
-
-    /**
-     * Setup the test environment.
-     *
-     * @return void
-     */
-    protected function setUp(): void
-    {
-        $this->file = self::randomFile();
-        parent::setUp();
+        // Map files into arrays to be passed to test methods
+        return array_map(
+            function (string $file) {
+                return [$file];
+            },
+            array_diff(scandir(__DIR__.'/Assets'), ['.', '..'])
+        );
     }
 }

--- a/tests/Unit/DownloadTest.php
+++ b/tests/Unit/DownloadTest.php
@@ -8,18 +8,30 @@ use Sfneal\Helpers\Aws\S3\Tests\StorageS3TestCase;
 
 class DownloadTest extends StorageS3TestCase
 {
-    /** @test */
-    public function file_can_be_downloaded()
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws \League\Flysystem\FileNotFoundException
+     */
+    public function file_can_be_downloaded(string $file)
     {
-        $storage = StorageS3::key($this->file);
+        $storage = StorageS3::key($file);
         $response = $storage->download();
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(file_get_contents($storage->url()), $response->content());
     }
 
-    /** @test */
-    public function file_download_headers_are_correct()
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws \League\Flysystem\FileNotFoundException
+     */
+    public function file_download_headers_are_correct(string $file)
     {
         $expectedHeaderKeys = [
             'Content-Type',
@@ -28,7 +40,7 @@ class DownloadTest extends StorageS3TestCase
             'Content-Disposition',
             'Content-Transfer-Encoding',
         ];
-        $storage = StorageS3::key($this->file);
+        $storage = StorageS3::key($file);
         $response = $storage->download();
 
         foreach ($expectedHeaderKeys as $key) {
@@ -36,10 +48,16 @@ class DownloadTest extends StorageS3TestCase
         }
     }
 
-    /** @test */
-    public function file_download_response_code()
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws \League\Flysystem\FileNotFoundException
+     */
+    public function file_download_response_code(string $file)
     {
-        $storage = StorageS3::key($this->file);
+        $storage = StorageS3::key($file);
         $response = $storage->download();
 
         $this->assertSame(200, $response->getStatusCode());

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -8,11 +8,11 @@ use Sfneal\Helpers\Aws\S3\Tests\StorageS3TestCase;
 
 class HelpersTest extends StorageS3TestCase
 {
-    private function executeAssertions($url)
+    private function executeAssertions($url, $file)
     {
         $this->assertNotNull($url);
         $this->assertIsString($url);
-        $this->assertStringContainsString($this->file, $url);
+        $this->assertStringContainsString($file, $url);
 
         $response = (new Client())->request('get', $url);
 
@@ -20,36 +20,52 @@ class HelpersTest extends StorageS3TestCase
         $this->assertEquals(file_get_contents($url), $response->getBody()->getContents());
     }
 
-    /** @test */
-    public function file_url_exists()
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     */
+    public function file_url_exists(string $file)
     {
-        $url = s3FileURL($this->file);
+        $url = s3FileURL($file);
 
-        $this->executeAssertions($url);
+        $this->executeAssertions($url, $file);
     }
 
-    /** @test */
-    public function file_url_temp_exists()
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     */
+    public function file_url_temp_exists(string $file)
     {
-        $url = s3FileUrlTemp($this->file);
+        $url = s3FileUrlTemp($file);
 
-        $this->executeAssertions($url);
-        $this->assertNotEquals(StorageS3::key($this->file)->url(), $url);
+        $this->executeAssertions($url, $file);
+        $this->assertNotEquals(StorageS3::key($file)->url(), $url);
     }
 
-    /** @test */
-    public function file_exists()
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     */
+    public function file_exists(string $file)
     {
-        $exists = s3Exists($this->file);
+        $exists = s3Exists($file);
 
         $this->assertIsBool($exists);
-        $this->assertTrue($exists, "The file '{$this->file}' doesn't exist.");
+        $this->assertTrue($exists, "The file '{$file}' doesn't exist.");
     }
 
-    /** @test */
-    public function file_doesnt_exist()
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     */
+    public function file_doesnt_exist(string $file)
     {
-        $doesntExist = s3Exists("fake_file_{$this->file}");
+        $doesntExist = s3Exists("fake_file_{$file}");
 
         $this->assertIsBool($doesntExist);
         $this->assertFalse($doesntExist);

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -14,17 +14,6 @@ class UploadTest extends StorageS3TestCase
     private $uploadPath;
 
     /**
-     * Setup the test environment.
-     *
-     * @return void
-     */
-    protected function setUp(): void
-    {
-        $this->uploadPath = "uploaded_{$this->file}";
-        parent::setUp();
-    }
-
-    /**
      * Clean up the testing environment before the next test.
      *
      * @return void
@@ -35,34 +24,44 @@ class UploadTest extends StorageS3TestCase
         parent::tearDown();
     }
 
-    /** @test */
-    public function file_can_be_uploaded()
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     */
+    public function file_can_be_uploaded(string $file)
     {
+        $this->uploadPath = "uploaded_{$file}";
         $s3Key = StorageS3::key($this->uploadPath)
-            ->upload(__DIR__.'/../Assets/'.$this->file)
+            ->upload(__DIR__.'/../Assets/'.$file)
             ->getKey();
 
         $exists = Storage::disk(config('filesystem.cloud', 's3'))->exists($s3Key);
 
         $this->assertIsBool($exists);
-        $this->assertTrue($exists, "The file '{$this->file}' doesn't exist.");
+        $this->assertTrue($exists, "The file '{$file}' doesn't exist.");
         $this->assertEquals(
             Storage::size($this->uploadPath),
             Storage::disk(config('filesystem.cloud', 's3'))->size($s3Key)
         );
     }
 
-    /** @test */
-    public function file_can_be_uploaded_raw()
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     */
+    public function file_can_be_uploaded_raw(string $file)
     {
+        $this->uploadPath = "uploaded_{$file}";
         $s3Key = StorageS3::key($this->uploadPath)
-            ->uploadRaw(file_get_contents(__DIR__.'/../Assets/'.$this->file))
+            ->uploadRaw(file_get_contents(__DIR__.'/../Assets/'.$file))
             ->getKey();
 
         $exists = Storage::disk(config('filesystem.cloud', 's3'))->exists($s3Key);
 
         $this->assertIsBool($exists);
-        $this->assertTrue($exists, "The file '{$this->file}' doesn't exist.");
+        $this->assertTrue($exists, "The file '{$file}' doesn't exist.");
         $this->assertEquals(
             Storage::size($this->uploadPath),
             Storage::disk(config('filesystem.cloud', 's3'))->size($s3Key)

--- a/tests/Unit/UrlTest.php
+++ b/tests/Unit/UrlTest.php
@@ -12,11 +12,11 @@ class UrlTest extends StorageS3TestCase
     /**
      * @throws GuzzleException
      */
-    private function executeAssertions($url)
+    private function executeAssertions($url, $file)
     {
         $this->assertNotNull($url);
         $this->assertIsString($url);
-        $this->assertStringContainsString($this->file, $url);
+        $this->assertStringContainsString($file, $url);
 
         $response = (new Client())->request('get', $url);
 
@@ -24,20 +24,30 @@ class UrlTest extends StorageS3TestCase
         $this->assertEquals(file_get_contents($url), $response->getBody()->getContents());
     }
 
-    /** @test */
-    public function url_is_valid()
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     * @throws GuzzleException
+     */
+    public function url_is_valid(string $file)
     {
-        $url = StorageS3::key($this->file)->url();
+        $url = StorageS3::key($file)->url();
 
-        $this->executeAssertions($url);
+        $this->executeAssertions($url, $file);
     }
 
-    /** @test */
-    public function temp_url_is_valid()
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     * @throws GuzzleException
+     */
+    public function temp_url_is_valid(string $file)
     {
-        $url = StorageS3::key($this->file)->urlTemp();
+        $url = StorageS3::key($file)->urlTemp();
 
-        $this->executeAssertions($url);
-        $this->assertNotEquals(StorageS3::key($this->file)->url(), $url);
+        $this->executeAssertions($url, $file);
+        $this->assertNotEquals(StorageS3::key($file)->url(), $url);
     }
 }


### PR DESCRIPTION
- add use of phpunit 'data providers' in order to run test methods on each test file (instead of a single random one)
- bump min laravel/framework version to v8.40 to avoid security vulnerabilities & improve Travis CI runtime