### PR TITLE
Fix issue with `S3HelpersServiceProvider` not being publishable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,3 +106,8 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 ## 0.11.0 - 2021-07-06
 - make 's3-helpers' config file that's booted & registered from the `S3HelpersServiceProvider`
 - add 's3-helpers' config file with 'expiration' key for setting default temp url expirations
+
+
+## 0.11.1 - 2021-07-06
+- fix issue with `S3HelpersServiceProvider` not being publishable
+- add test methods to `UrlTest` for testing expired temp urls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 - add use of phpunit 'data providers' in order to run test methods on each test file (instead of a single random one)
 - bump min laravel/framework version to v8.40 to avoid security vulnerabilities & improve Travis CI runtime
 
+
 ## 0.11.0 - 2021-07-06
 - make 's3-helpers' config file that's booted & registered from the `S3HelpersServiceProvider`
 - add 's3-helpers' config file with 'expiration' key for setting default temp url expirations

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Sfneal\\Helpers\\AWS\\S3\\Providers\\S3HelpersServiceProvider"
+                "Sfneal\\Helpers\\Aws\\S3\\Providers\\S3HelpersServiceProvider"
             ]
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,13 @@
             "src/Helpers/s3-helpers.php"
         ]
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Sfneal\\Helpers\\AWS\\S3\\Providers\\S3HelpersServiceProvider"
+            ]
+        }
+    },
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage",

--- a/src/Providers/S3HelpersServiceProvider.php
+++ b/src/Providers/S3HelpersServiceProvider.php
@@ -7,7 +7,7 @@ use Illuminate\Support\ServiceProvider;
 class S3HelpersServiceProvider extends ServiceProvider
 {
     /**
-     * Bootstrap any CrudModelAction services.
+     * Bootstrap any AWS S3 Helper services.
      *
      * @return void
      */
@@ -20,7 +20,7 @@ class S3HelpersServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register any CrudModelAction services.
+     * Register any AWS S3 Helper services.
      *
      * @return void
      */


### PR DESCRIPTION
- fix issue with `S3HelpersServiceProvider` not being publishable
- add test methods to `UrlTest` for testing expired temp urls