### PR TITLE
S3::allFiles()` & `S3::allDirectories()` methods to return collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,3 +111,7 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 ## 0.11.1 - 2021-07-06
 - fix issue with `S3HelpersServiceProvider` not being publishable
 - add test methods to `UrlTest` for testing expired temp urls
+
+
+## 0.11.2 - 2021-07-06
+- fix `S3::allFiles()` & `S3::allDirectories()` methods to return collections instead of arrays

--- a/src/Interfaces/S3Filesystem.php
+++ b/src/Interfaces/S3Filesystem.php
@@ -6,6 +6,7 @@ use Closure;
 use DateTimeInterface;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Http\Response;
+use Illuminate\Support\Collection;
 
 interface S3Filesystem
 {
@@ -65,15 +66,15 @@ interface S3Filesystem
      * Retrieve an array of all files in a directory with an optional filtering closure.
      *
      * @param Closure|null $closure
-     * @return array
+     * @return Collection
      */
-    public function allFiles(Closure $closure = null): array;
+    public function allFiles(Closure $closure = null): Collection;
 
     /**
      * Retrieve an array of all directories within another directory with an optional filtering closure.
      *
      * @param Closure|null $closure
-     * @return array
+     * @return Collection
      */
-    public function allDirectories(Closure $closure = null): array;
+    public function allDirectories(Closure $closure = null): Collection;
 }

--- a/src/Utils/S3.php
+++ b/src/Utils/S3.php
@@ -7,6 +7,7 @@ use DateTimeInterface;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Storage;
 use Sfneal\Helpers\Aws\S3\Interfaces\S3Filesystem;
@@ -168,16 +169,16 @@ class S3 implements S3Filesystem
      * Retrieve an array of all files in a directory with an optional filtering closure.
      *
      * @param Closure|null $closure
-     * @return array
+     * @return Collection
      */
-    public function allFiles(Closure $closure = null): array
+    public function allFiles(Closure $closure = null): Collection
     {
         // Create array of all files
-        $allFiles = $this->storageDisk()->allFiles($this->s3Key);
+        $allFiles = collect($this->storageDisk()->allFiles($this->s3Key));
 
         // Apply filtering closure
         if (isset($closure)) {
-            return array_filter(array_values($allFiles), $closure);
+            return $allFiles->filter($closure);
         }
 
         return $allFiles;
@@ -187,16 +188,16 @@ class S3 implements S3Filesystem
      * Retrieve an array of all directories within another directory with an optional filtering closure.
      *
      * @param Closure|null $closure
-     * @return array
+     * @return Collection
      */
-    public function allDirectories(Closure $closure = null): array
+    public function allDirectories(Closure $closure = null): Collection
     {
         // Create array of all directories
-        $allDirectories = $this->storageDisk()->allDirectories($this->s3Key);
+        $allDirectories = collect($this->storageDisk()->allDirectories($this->s3Key));
 
         // Apply filtering closure
         if (isset($closure)) {
-            return array_filter(array_values($allDirectories), $closure);
+            return $allDirectories->filter($closure);
         }
 
         return $allDirectories;

--- a/tests/Unit/AllDirectoriesTest.php
+++ b/tests/Unit/AllDirectoriesTest.php
@@ -2,6 +2,8 @@
 
 namespace Sfneal\Helpers\Aws\S3\Tests\Unit;
 
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
 use Sfneal\Helpers\Aws\S3\StorageS3;
 use Sfneal\Helpers\Aws\S3\Tests\TestCase;
 
@@ -9,16 +11,20 @@ class AllDirectoriesTest extends TestCase
 {
     private function executeAssertions($expected, $allDirectories)
     {
+        $array = $allDirectories->toArray();
+
         $this->assertNotNull($allDirectories);
-        $this->assertIsArray($allDirectories);
+        $this->assertInstanceOf(Collection::class, $allDirectories);
+        $this->assertIsArray($array);
 
         foreach ($expected as $expect) {
-            $this->assertTrue(in_array($expect, $allDirectories));
+            $this->assertTrue(in_array($expect, $array));
+            Storage::disk(config('filesystem.cloud', 's3'))->exists($expect);
         }
 
         sort($expected);
-        sort($allDirectories);
-        $this->assertEquals($expected, $allDirectories);
+        sort($array);
+        $this->assertEquals($expected, $array);
     }
 
     /** @test */

--- a/tests/Unit/AllFilesTest.php
+++ b/tests/Unit/AllFilesTest.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Helpers\Aws\S3\Tests\Unit;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use Sfneal\Helpers\Aws\S3\StorageS3;
 use Sfneal\Helpers\Aws\S3\Tests\TestCase;
@@ -10,17 +11,20 @@ class AllFilesTest extends TestCase
 {
     private function executeAssertions($expected, $allFiles)
     {
+        $array = $allFiles->toArray();
+
         $this->assertNotNull($allFiles);
-        $this->assertIsArray($allFiles);
+        $this->assertInstanceOf(Collection::class, $allFiles);
+        $this->assertIsArray($array);
 
         foreach ($expected as $expect) {
-            $this->assertTrue(in_array($expect, $allFiles));
+            $this->assertTrue(in_array($expect, $array));
             Storage::disk(config('filesystem.cloud', 's3'))->exists($expect);
         }
 
         sort($expected);
-        sort($allFiles);
-        $this->assertEquals($expected, $allFiles);
+        sort($array);
+        $this->assertEquals($expected, $array);
     }
 
     /** @test */


### PR DESCRIPTION
- fix `S3::allFiles()` & `S3::allDirectories()` methods to return collections instead of arrays