### PR TITLE
Post upload local file deleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,3 +130,9 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 
 ## 0.12.2 - 2021-07-07
 - make `CloudStorage` util class for housing properties, getters & setters
+
+
+## 0.13.0 - 2021-07-07
+- add ability to delete a local file after it's been uploaded
+- fix issues with `UploadTest::executeAssertions()` method not comparing local & cloud files
+- add test methods to `UploadTest` for testing deleting local files (w/streaming enabled & disabled)

--- a/src/Utils/CloudStorage.php
+++ b/src/Utils/CloudStorage.php
@@ -26,6 +26,11 @@ class CloudStorage
     protected $streaming;
 
     /**
+     * @var bool Enable/disable deleting the local file after it's been uploaded
+     */
+    protected $deleteLocalFileAfterUpload = false;
+
+    /**
      * S3 constructor.
      *
      * @param string $s3Key
@@ -55,6 +60,28 @@ class CloudStorage
     protected function isStreamingEnabled(): bool
     {
         return $this->streaming;
+    }
+
+    /**
+     * Determine if deleting the local file after it's been uploaded is enabled.
+     *
+     * @return bool
+     */
+    private function isLocalFileDeletingEnabled(): bool
+    {
+        return $this->deleteLocalFileAfterUpload;
+    }
+
+    /**
+     * Delete the local file path if post upload file deletion is enabled.
+     *
+     * @param string $localFilePath
+     */
+    protected function deleteLocalFileIfEnabled(string $localFilePath): void
+    {
+        if ($this->isLocalFileDeletingEnabled()) {
+            unlink($localFilePath);
+        }
     }
 
     /**
@@ -100,6 +127,18 @@ class CloudStorage
     public function disableStreaming(): self
     {
         $this->streaming = false;
+
+        return $this;
+    }
+
+    /**
+     * Enable deleting the local file after it's been uploaded.
+     *
+     * @return $this
+     */
+    public function enableDeleteLocalFileAfterUpload(): self
+    {
+        $this->deleteLocalFileAfterUpload = true;
 
         return $this;
     }

--- a/src/Utils/CloudStorage.php
+++ b/src/Utils/CloudStorage.php
@@ -34,7 +34,6 @@ class CloudStorage
     {
         $this->s3Key = $s3Key;
         $this->disk = config('filesystem.cloud', 's3');
-        $this->streaming = config('s3-helpers.streaming', true);
     }
 
     /**

--- a/src/Utils/CloudStorage.php
+++ b/src/Utils/CloudStorage.php
@@ -7,9 +7,14 @@ namespace Sfneal\Helpers\Aws\S3\Utils;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Storage;
+use Sfneal\Helpers\Aws\S3\Utils\Traits\LocalFileDeletion;
+use Sfneal\Helpers\Aws\S3\Utils\Traits\UploadStreaming;
 
 class CloudStorage
 {
+    use LocalFileDeletion;
+    use UploadStreaming;
+
     /**
      * @var string AWS S3 file key
      */
@@ -21,16 +26,6 @@ class CloudStorage
     protected $disk;
 
     /**
-     * @var bool Enable/disable upload & download streaming
-     */
-    protected $streaming;
-
-    /**
-     * @var bool Enable/disable deleting the local file after it's been uploaded
-     */
-    protected $deleteLocalFileAfterUpload = false;
-
-    /**
      * S3 constructor.
      *
      * @param string $s3Key
@@ -40,48 +35,6 @@ class CloudStorage
         $this->s3Key = $s3Key;
         $this->disk = config('filesystem.cloud', 's3');
         $this->streaming = config('s3-helpers.streaming', true);
-    }
-
-    /**
-     * Retrieve a Filesystem instance for the specified disk.
-     *
-     * @return Filesystem|FilesystemAdapter
-     */
-    protected function storageDisk(): FilesystemAdapter
-    {
-        return Storage::disk($this->disk);
-    }
-
-    /**
-     * Determine if upload/download streaming is enabled.
-     *
-     * @return bool
-     */
-    protected function isStreamingEnabled(): bool
-    {
-        return $this->streaming;
-    }
-
-    /**
-     * Determine if deleting the local file after it's been uploaded is enabled.
-     *
-     * @return bool
-     */
-    private function isLocalFileDeletingEnabled(): bool
-    {
-        return $this->deleteLocalFileAfterUpload;
-    }
-
-    /**
-     * Delete the local file path if post upload file deletion is enabled.
-     *
-     * @param string $localFilePath
-     */
-    protected function deleteLocalFileIfEnabled(string $localFilePath): void
-    {
-        if ($this->isLocalFileDeletingEnabled()) {
-            unlink($localFilePath);
-        }
     }
 
     /**
@@ -108,38 +61,12 @@ class CloudStorage
     }
 
     /**
-     * Enable upload/download streaming regardless of config setting.
+     * Retrieve a Filesystem instance for the specified disk.
      *
-     * @return $this
+     * @return Filesystem|FilesystemAdapter
      */
-    public function enableStreaming(): self
+    protected function storageDisk(): FilesystemAdapter
     {
-        $this->streaming = true;
-
-        return $this;
-    }
-
-    /**
-     * Disable upload/download streaming regardless of config setting.
-     *
-     * @return $this
-     */
-    public function disableStreaming(): self
-    {
-        $this->streaming = false;
-
-        return $this;
-    }
-
-    /**
-     * Enable deleting the local file after it's been uploaded.
-     *
-     * @return $this
-     */
-    public function enableDeleteLocalFileAfterUpload(): self
-    {
-        $this->deleteLocalFileAfterUpload = true;
-
-        return $this;
+        return Storage::disk($this->disk);
     }
 }

--- a/src/Utils/S3.php
+++ b/src/Utils/S3.php
@@ -47,13 +47,18 @@ class S3 extends CloudStorage implements S3Filesystem
     {
         // Use streaming for improved performance if enabled
         if ($this->isStreamingEnabled()) {
-            return $this->uploadStream($localFilePath, $acl);
+            $this->uploadStream($localFilePath, $acl);
         }
 
         // Use standard file uploading
         else {
-            return $this->uploadRaw(fopen($localFilePath, 'r+'), $acl);
+            $this->uploadRaw(fopen($localFilePath, 'r+'), $acl);
         }
+
+        // Conditionally delete the local file
+        $this->deleteLocalFileIfEnabled($localFilePath);
+
+        return $this;
     }
 
     /**
@@ -79,6 +84,7 @@ class S3 extends CloudStorage implements S3Filesystem
      */
     protected function uploadStream(string $localFilePath, string $acl = null): self
     {
+        // Upload the file
         $this->storageDisk()->putFileAs(
             dirname($this->s3Key),
             new File($localFilePath),

--- a/src/Utils/Traits/LocalFileDeletion.php
+++ b/src/Utils/Traits/LocalFileDeletion.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Helpers\Aws\S3\Utils\Traits;
-
 
 trait LocalFileDeletion
 {

--- a/src/Utils/Traits/LocalFileDeletion.php
+++ b/src/Utils/Traits/LocalFileDeletion.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Sfneal\Helpers\Aws\S3\Utils\Traits;
+
+
+trait LocalFileDeletion
+{
+    /**
+     * @var bool Enable/disable deleting the local file after it's been uploaded
+     */
+    protected $deleteLocalFileAfterUpload = false;
+
+    /**
+     * Enable deleting the local file after it's been uploaded.
+     *
+     * @return $this
+     */
+    public function enableDeleteLocalFileAfterUpload(): self
+    {
+        $this->deleteLocalFileAfterUpload = true;
+
+        return $this;
+    }
+
+    /**
+     * Delete the local file path if post upload file deletion is enabled.
+     *
+     * @param string $localFilePath
+     */
+    protected function deleteLocalFileIfEnabled(string $localFilePath): void
+    {
+        if ($this->isLocalFileDeletingEnabled()) {
+            unlink($localFilePath);
+        }
+    }
+
+    /**
+     * Determine if deleting the local file after it's been uploaded is enabled.
+     *
+     * @return bool
+     */
+    private function isLocalFileDeletingEnabled(): bool
+    {
+        return $this->deleteLocalFileAfterUpload;
+    }
+}

--- a/src/Utils/Traits/LocalFileDeletion.php
+++ b/src/Utils/Traits/LocalFileDeletion.php
@@ -16,7 +16,7 @@ trait LocalFileDeletion
      *
      * @return $this
      */
-    public function enableDeleteLocalFileAfterUpload(): self
+    public function deleteLocalFileAfterUpload(): self
     {
         $this->deleteLocalFileAfterUpload = true;
 

--- a/src/Utils/Traits/UploadStreaming.php
+++ b/src/Utils/Traits/UploadStreaming.php
@@ -42,6 +42,6 @@ trait UploadStreaming
      */
     protected function isStreamingEnabled(): bool
     {
-        return $this->streaming;
+        return $this->streaming ?? config('s3-helpers.streaming', true);
     }
 }

--- a/src/Utils/Traits/UploadStreaming.php
+++ b/src/Utils/Traits/UploadStreaming.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Helpers\Aws\S3\Utils\Traits;
-
 
 trait UploadStreaming
 {

--- a/src/Utils/Traits/UploadStreaming.php
+++ b/src/Utils/Traits/UploadStreaming.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Sfneal\Helpers\Aws\S3\Utils\Traits;
+
+
+trait UploadStreaming
+{
+    /**
+     * @var bool Enable/disable upload & download streaming
+     */
+    protected $streaming;
+
+    /**
+     * Enable upload/download streaming regardless of config setting.
+     *
+     * @return $this
+     */
+    public function enableStreaming(): self
+    {
+        $this->streaming = true;
+
+        return $this;
+    }
+
+    /**
+     * Disable upload/download streaming regardless of config setting.
+     *
+     * @return $this
+     */
+    public function disableStreaming(): self
+    {
+        $this->streaming = false;
+
+        return $this;
+    }
+
+    /**
+     * Determine if upload/download streaming is enabled.
+     *
+     * @return bool
+     */
+    protected function isStreamingEnabled(): bool
+    {
+        return $this->streaming;
+    }
+}

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -88,4 +88,52 @@ class UploadTest extends StorageS3TestCase
 
         $this->executeAssertions($file, $s3Key);
     }
+
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     */
+    public function file_can_be_uploaded_and_local_file_deleted(string $file)
+    {
+        $tempFile = "temp_{$file}";
+        $this->assertTrue(copy(__DIR__.'/../Assets/'.$file, __DIR__.'/../Assets/'.$tempFile));
+
+        $localPath = __DIR__.'/../Assets/'.$tempFile;
+        $this->uploadPath = "uploaded_{$tempFile}";
+        $this->assertTrue(file_exists($localPath));
+
+        $s3Key = StorageS3::key($this->uploadPath)
+            ->disableStreaming()
+            ->deleteLocalFileAfterUpload()
+            ->upload($localPath)
+            ->getKey();
+
+        $this->executeAssertions($file, $s3Key);
+        $this->assertFalse(file_exists($localPath));
+    }
+
+    /**
+     * @test
+     * @dataProvider fileProvider
+     * @param string $file
+     */
+    public function file_can_be_uploaded_and_local_file_deleted_with_streaming(string $file)
+    {
+        $tempFile = "temp_{$file}";
+        $this->assertTrue(copy(__DIR__.'/../Assets/'.$file, __DIR__.'/../Assets/'.$tempFile));
+
+        $localPath = __DIR__.'/../Assets/'.$tempFile;
+        $this->uploadPath = "uploaded_{$tempFile}";
+        $this->assertTrue(file_exists($localPath));
+
+        $s3Key = StorageS3::key($this->uploadPath)
+            ->enableStreaming()
+            ->deleteLocalFileAfterUpload()
+            ->upload($localPath)
+            ->getKey();
+
+        $this->executeAssertions($file, $s3Key);
+        $this->assertFalse(file_exists($localPath));
+    }
 }

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -37,7 +37,7 @@ class UploadTest extends StorageS3TestCase
         $this->assertIsBool($exists);
         $this->assertTrue($exists, "The file '{$file}' doesn't exist.");
         $this->assertEquals(
-            Storage::size($this->uploadPath),
+            filesize(__DIR__.'/../Assets/'.$file),
             Storage::disk(config('filesystem.cloud', 's3'))->size($s3Key)
         );
     }


### PR DESCRIPTION
- add ability to delete a local file after it's been uploaded
- fix issues with `UploadTest::executeAssertions()` method not comparing local & cloud files
- add test methods to `UploadTest` for testing deleting local files (w/streaming enabled & disabled)