### PR TITLE
refactor test suite to use `Http` facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,3 +148,7 @@ All notable changes to `aws-s3-helpers` will be documented in this file
 - initial production release
 - refactor `CloudStorage` so that $disk is now a constructor param instead of requiring a call to a setter method
 - refactor interfaces from `Sfneal\Helpers\Aws\S3\Interfaces` to `Sfneal\Helpers\Aws\S3\Utils\Interfaces` namespace
+
+
+## 1.0.1 - 2021-07-09
+- refactor test suite to use `Http` facade instead of `GuzzleHttp\Client` for testing responses

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -2,7 +2,7 @@
 
 namespace Sfneal\Helpers\Aws\S3\Tests\Unit;
 
-use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Http;
 use Sfneal\Helpers\Aws\S3\StorageS3;
 use Sfneal\Helpers\Aws\S3\Tests\StorageS3TestCase;
 
@@ -14,10 +14,10 @@ class HelpersTest extends StorageS3TestCase
         $this->assertIsString($url);
         $this->assertStringContainsString($file, $url);
 
-        $response = (new Client())->request('get', $url);
+        $response = Http::get($url);
 
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(file_get_contents($url), $response->getBody()->getContents());
+        $this->assertTrue($response->ok());
+        $this->assertEquals(file_get_contents($url), $response->body());
     }
 
     /**

--- a/tests/Unit/UrlTest.php
+++ b/tests/Unit/UrlTest.php
@@ -2,33 +2,28 @@
 
 namespace Sfneal\Helpers\Aws\S3\Tests\Unit;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Support\Facades\Http;
 use Sfneal\Helpers\Aws\S3\StorageS3;
 use Sfneal\Helpers\Aws\S3\Tests\StorageS3TestCase;
 
 class UrlTest extends StorageS3TestCase
 {
-    /**
-     * @throws GuzzleException
-     */
     private function executeAssertions($url, $file)
     {
         $this->assertNotNull($url);
         $this->assertIsString($url);
         $this->assertStringContainsString($file, $url);
 
-        $response = (new Client())->request('get', $url);
+        $response = Http::get($url);
 
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(file_get_contents($url), $response->getBody()->getContents());
+        $this->assertTrue($response->ok());
+        $this->assertEquals(file_get_contents($url), $response->body());
     }
 
     /**
      * @test
      * @dataProvider fileProvider
      * @param string $file
-     * @throws GuzzleException
      */
     public function url_is_valid(string $file)
     {
@@ -41,7 +36,6 @@ class UrlTest extends StorageS3TestCase
      * @test
      * @dataProvider fileProvider
      * @param string $file
-     * @throws GuzzleException
      */
     public function temp_url_is_valid(string $file)
     {
@@ -61,13 +55,8 @@ class UrlTest extends StorageS3TestCase
         $url = StorageS3::key($file)->urlTemp(now()->addSecond());
 
         sleep(1);
-        try {
-            $response = (new Client())->request('get', $url);
-            $this->assertEquals(403, $response->getStatusCode());
-        } catch (GuzzleException $exception) {
-            $this->assertInstanceOf(GuzzleException::class, $exception);
-            $this->assertEquals(403, $exception->getCode());
-        }
+        $response = Http::get($url);
+        $this->assertEquals(403, $response->status());
     }
 
     /**
@@ -79,12 +68,7 @@ class UrlTest extends StorageS3TestCase
     {
         $url = StorageS3::key($file)->urlTemp(now()->subMinute());
 
-        try {
-            $response = (new Client())->request('get', $url);
-            $this->assertEquals(400, $response->getStatusCode());
-        } catch (GuzzleException $exception) {
-            $this->assertInstanceOf(GuzzleException::class, $exception);
-            $this->assertEquals(400, $exception->getCode());
-        }
+        $response = Http::get($url);
+        $this->assertEquals(400, $response->status());
     }
 }


### PR DESCRIPTION
- refactor test suite to use `Http` facade instead of `GuzzleHttp\Client` for testing responses